### PR TITLE
Change command to run cypress

### DIFF
--- a/tool.py
+++ b/tool.py
@@ -930,7 +930,7 @@ class CloudBuilder:
         if self.args.puppeteer:
             testcmd = basecmd + 'npm run tests:integration:puppeteer"'
         elif self.args.cypress or self.args.cypress_debug:
-            testcmd = basecmd + 'npm run integration_headless'
+            testcmd = basecmd + 'npm run integration_headless"'
         else:
             testcmd = basecmd + './node_modules/jest/bin/jest.js src/index.test.js"'
 

--- a/tool.py
+++ b/tool.py
@@ -930,7 +930,7 @@ class CloudBuilder:
         if self.args.puppeteer:
             testcmd = basecmd + 'npm run tests:integration:puppeteer"'
         elif self.args.cypress or self.args.cypress_debug:
-            testcmd = basecmd + 'cypress run --headless --browser chrome --spec cypress/integration/automation-analytics.js"'
+            testcmd = basecmd + 'npm run integration_headless'
         else:
             testcmd = basecmd + './node_modules/jest/bin/jest.js src/index.test.js"'
 

--- a/tool.py
+++ b/tool.py
@@ -930,7 +930,7 @@ class CloudBuilder:
         if self.args.puppeteer:
             testcmd = basecmd + 'npm run tests:integration:puppeteer"'
         elif self.args.cypress or self.args.cypress_debug:
-            testcmd = basecmd + 'npm run integration_headless"'
+            testcmd = basecmd + 'cypress run --headless --browser chrome"'
         else:
             testcmd = basecmd + './node_modules/jest/bin/jest.js src/index.test.js"'
 


### PR DESCRIPTION
For Automation Analytics fronted workflow we need to change the arguments passed to the cypress, this change would modify the pipeline so it runs a command from the package.json file instead of a hardcoded cypress command.

P.S.: I am definitely not sure if this would work or not.