### PR TITLE
Change command to run cypress - 2nd try

### DIFF
--- a/genstack.yml
+++ b/genstack.yml
@@ -93,7 +93,7 @@ services:
             - sso.local.redhat.com
             - kcadmin
             - aabackend
-        command: /bin/bash -c "cd /app && npm install && ./wait_for_stack.sh && timeout -s SIGKILL 1000s npm run integration_headless"
+        command: /bin/bash -c "cd /app && npm install && ./wait_for_stack.sh && timeout -s SIGKILL 1000s cypress run --headless --browser chrome"
         environment:
             CYPRESS_CLOUD_BASE_URL: https://prod.foo.redhat.com:8443
             CYPRESS_CLOUD_USERNAME: bob

--- a/genstack.yml
+++ b/genstack.yml
@@ -93,7 +93,7 @@ services:
             - sso.local.redhat.com
             - kcadmin
             - aabackend
-        command: /bin/bash -c "cd /app && npm install && ./wait_for_stack.sh && timeout -s SIGKILL 1000s cypress run --headless --browser chrome --spec cypress/integration/automation-analytics.js"
+        command: /bin/bash -c "cd /app && npm install && ./wait_for_stack.sh && timeout -s SIGKILL 1000s npm run integration_headless"
         environment:
             CYPRESS_CLOUD_BASE_URL: https://prod.foo.redhat.com:8443
             CYPRESS_CLOUD_USERNAME: bob


### PR DESCRIPTION
For Automation Analytics fronted workflow we need to change the arguments passed to the cypress, this change would modify the pipeline so it runs a command from the package.json file instead of a hardcoded cypress command.